### PR TITLE
Update rtfdocvisitor.cpp

### DIFF
--- a/src/rtfdocvisitor.cpp
+++ b/src/rtfdocvisitor.cpp
@@ -544,7 +544,7 @@ void RTFDocVisitor::visitPost(DocAutoList *)
 {
   if (m_hide) return;
   DBG_RTF("{\\comment RTFDocVisitor::visitPost(DocAutoList)}\n");
-  m_t << "\\par";
+  if (!m_lastIsPara) m_t << "\\par" << endl;
   m_t << "}" << endl;
   m_lastIsPara=TRUE;
 }


### PR DESCRIPTION
turned off the automatic generation of the additional and uneccessary bullet points, which were automatically created
